### PR TITLE
Correct pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This python api enables easy interaction with the Etherpad API.  Etherpad is a c
 # 1 Installation
 
 ```
-pip install pythetherpadlite
+pip install pyetherpadlite
 ```
 
 


### PR DESCRIPTION
In PyPi, this Python package is named `pyetherpadlite`, not `pythetherpadlite`. The pip install will fail with the current install instructions. Correct the instructions to use the right package name.